### PR TITLE
Add keyboard shortcuts for sending message and closing modal

### DIFF
--- a/client/src/pages/Dashboard/project-view/components/ChatModal.jsx
+++ b/client/src/pages/Dashboard/project-view/components/ChatModal.jsx
@@ -57,6 +57,23 @@ const ChatModal = () => {
     }
     setIsLikeDislikeUpdate(false); // Reset after handling
   }, [messages]);
+
+  // Add this useEffect hook for keyboard events
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Enter') {
+        sendMessage();
+      } else if (e.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [message, isOpen]);
   
 
   const handleLikeDislike = async (commentId, isLike) => {


### PR DESCRIPTION
Implement keyboard event listeners to allow sending messages with the 'Enter' key and closing the chat modal with the 'Escape' key for improved user experience.